### PR TITLE
Added Notifications

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -2,8 +2,10 @@ const express = require("express");
 const router = express.Router();
 const profileRouter = require("./users");
 const calendarItemsRouter = require("./calendarItems");
+const notificationsRouter = require("./notifications");
 
 router.use("/profiles", profileRouter);
 router.use("/calendarItems", calendarItemsRouter);
+router.use("/notifications", notificationsRouter);
 
 module.exports = router;

--- a/api/notifications.js
+++ b/api/notifications.js
@@ -56,7 +56,7 @@ router.get("/me", authenticateJWT, async (req, res) => {
       
       if (notif.request_notification) {
         notifInfo.type = 'request';
-        notifInfo.status = notif.request_notification.status;
+        notifInfo.status = notif.request_notification.friendship.status;
         const otherUser = notif.request_notification.friendship.primary.id === userId ?
           notif.request_notification.friendship.secondary : notif.request_notification.friendship.primary;
         notifInfo.otherUser = {

--- a/api/notifications.js
+++ b/api/notifications.js
@@ -1,5 +1,6 @@
 const express = require("express");
 const Notification = require("../database/notification");
+const { authenticateJWT } = require("../auth");
 const router = express.Router();
 
 router.get("/", async (req, res) => {
@@ -9,6 +10,23 @@ router.get("/", async (req, res) => {
   } catch (error) {
     console.log(error);
     res.status(500).send({ error: `Error getting all notifications: ${error}` });
+  }
+});
+
+router.get("/me", authenticateJWT, async (req, res) => {
+  const userId = req.user.id;
+  try {
+    const notifs = await Notification.findAll({
+      where: { userId },
+      order: [['createdAt', 'DESC']],
+    });
+    res.status(200).json({
+      message: "Successfully retrieved user's notifications",
+      notifications: notifs,
+    });
+  } catch (error) {
+    console.error("Error fetching user's notifications:", error);
+    res.status(500).json({ error: "Failed to get user's notifications" });
   }
 });
 

--- a/api/notifications.js
+++ b/api/notifications.js
@@ -4,16 +4,6 @@ const { authenticateJWT } = require("../auth");
 const { RequestNotification, ReminderNotification, EventNotification, FriendShip, User } = require("../database");
 const router = express.Router();
 
-router.get("/", async (req, res) => {
-  try {
-    const notifs = await Notification.findAll();
-    res.status(200).send(notifs);
-  } catch (error) {
-    console.log(error);
-    res.status(500).send({ error: `Error getting all notifications: ${error}` });
-  }
-});
-
 router.get("/me", authenticateJWT, async (req, res) => {
   const userId = req.user.id;
   try {

--- a/api/notifications.js
+++ b/api/notifications.js
@@ -1,6 +1,7 @@
 const express = require("express");
 const Notification = require("../database/notification");
 const { authenticateJWT } = require("../auth");
+const { RequestNotification, ReminderNotification, EventNotification, FriendShip, User } = require("../database");
 const router = express.Router();
 
 router.get("/", async (req, res) => {
@@ -18,8 +19,58 @@ router.get("/me", authenticateJWT, async (req, res) => {
   try {
     const notifs = await Notification.findAll({
       where: { userId },
+      include: [
+        {
+          model: RequestNotification,
+          required: false,
+          include: [
+            {
+              model: FriendShip,
+              include: [
+                {
+                  model: User,
+                  as: 'primary'
+                },
+                {
+                  model: User,
+                  as: 'secondary'
+                },
+              ],
+            },
+          ],
+        },
+        { model: ReminderNotification, required: false },
+        { model: EventNotification, required: false },
+      ],
       order: [['createdAt', 'DESC']],
     });
+
+    notifs.forEach((notif, index, array) => {
+      const notifInfo = {
+        id: notif.id,
+        time: notif.createdAt,
+        read: notif.read,
+        userId: notif.userId,
+        type: 'blank',
+      }
+      
+      if (notif.request_notification) {
+        notifInfo.type = 'request';
+        notifInfo.status = notif.request_notification.status;
+        const otherUser = notif.request_notification.friendship.primary.id === userId ?
+          notif.request_notification.friendship.secondary : notif.request_notification.friendship.primary;
+        notifInfo.otherUser = {
+          id: otherUser.id,
+          firstName: otherUser.firstName,
+          username: otherUser.username,
+        }
+      }
+      // ELSE IF REMINDER NOTIF
+      // ELSE IF EVENT NOTIF
+
+      array[index] = notifInfo;
+    });
+
     res.status(200).json({
       message: "Successfully retrieved user's notifications",
       notifications: notifs,

--- a/api/notifications.js
+++ b/api/notifications.js
@@ -1,0 +1,15 @@
+const express = require("express");
+const Notification = require("../database/notification");
+const router = express.Router();
+
+router.get("/", async (req, res) => {
+  try {
+    const notifs = await Notification.findAll();
+    res.status(200).send(notifs);
+  } catch (error) {
+    console.log(error);
+    res.status(500).send({ error: `Error getting all notifications: ${error}` });
+  }
+});
+
+module.exports = router;

--- a/database/event_notification.js
+++ b/database/event_notification.js
@@ -1,0 +1,19 @@
+const { DataTypes } = require("sequelize");
+const db = require("./db");
+
+const EventNotification = db.define("event_notification", {
+  notificationId: {
+    type: DataTypes.INTEGER,
+    primaryKey: true,
+  },
+  eventId: {
+    type: DataTypes.INTEGER,
+    primaryKey: true,
+  },
+  type: {
+    type: DataTypes.ENUM(['reminder', 'starting', 'cancelled', 'invite']),
+    allowNull: false,
+  },
+});
+
+module.exports = EventNotification;

--- a/database/friendship.js
+++ b/database/friendship.js
@@ -2,20 +2,30 @@ const { DataTypes } = require("sequelize");
 const db = require("./db");
 
 const FriendShip = db.define("friendship", {
+  id: {
+    type: DataTypes.INTEGER,
+    autoIncrement: true,
+    primaryKey: true,
+  },
   user1: {
     type: DataTypes.INTEGER,
     allowNull: false,
-    primaryKey: true,
   },
   user2: {
     type: DataTypes.INTEGER,
     allowNull: false,
-    primaryKey: true,
   },
   status: {
     type: DataTypes.ENUM(["pending1", "pending2", "accepted"]),
     allowNull: false,
   },
+}, {
+  indexes: [
+    {
+      unique: true,
+      fields: ['user1', 'user2'],
+    },
+  ],
 }, {
   validate: {
     idsInOrder() {

--- a/database/index.js
+++ b/database/index.js
@@ -7,6 +7,7 @@ const Follow = require("./follow");
 const Attendee = require("./attendee");
 const Event = require("./event");
 const Reminder = require("./reminders");
+const Notification = require("./notification");
 
 // -------------- Associations -----------------//
 // User owns a business
@@ -97,6 +98,15 @@ Follow.belongsTo(User, {
   foreignKey: 'userId'
 });
 
+//------------------------------------------
+// User has notifications
+User.hasMany(Notification, {
+  foreignKey: 'userId',
+});
+Notification.belongsTo(User, {
+  foreignKey: 'userId',
+}),
+
 module.exports = {
   db,
   User,
@@ -107,4 +117,5 @@ module.exports = {
   Follow,
   Attendee,
   Reminder,
+  Notification,
 };

--- a/database/index.js
+++ b/database/index.js
@@ -8,6 +8,9 @@ const Attendee = require("./attendee");
 const Event = require("./event");
 const Reminder = require("./reminders");
 const Notification = require("./notification");
+const RequestNotification = require("./request_notification");
+const ReminderNotification = require("./reminder_notification");
+const EventNotification = require("./event_notification");
 
 // -------------- Associations -----------------//
 // User owns a business
@@ -107,6 +110,60 @@ Notification.belongsTo(User, {
   foreignKey: 'userId',
 }),
 
+//------------------------------------------
+// Notification can be a friend request notification
+Notification.hasOne(RequestNotification, {
+  foreignKey: 'notificationId',
+});
+RequestNotification.belongsTo(Notification, {
+  foreignKey: 'notificationId',
+});
+
+//------------------------------------------
+// Request notifications reference a friendship
+FriendShip.hasMany(RequestNotification, {
+  foreignKey: 'friendshipId',
+});
+RequestNotification.belongsTo(FriendShip, {
+  foreignKey: 'friendshipId',
+});
+
+//------------------------------------------
+// Notification can be a reminder notification
+Notification.hasOne(ReminderNotification, {
+  foreignKey: 'notificationId',
+});
+ReminderNotification.belongsTo(Notification, {
+  foreignKey: 'notificationId',
+});
+
+//------------------------------------------
+// Reminder notifications reference a reminder
+Reminder.hasOne(ReminderNotification, {
+  foreignKey: 'reminderId',
+});
+ReminderNotification.belongsTo(Reminder, {
+  foreignKey: 'reminderId',
+});
+
+//------------------------------------------
+// Notification can be an event notification
+Notification.hasOne(EventNotification, {
+  foreignKey: 'notificationId',
+});
+EventNotification.belongsTo(Notification, {
+  foreignKey: 'notificationId',
+});
+
+//------------------------------------------
+// Event notifications reference an event
+Event.hasMany(EventNotification, {
+  foreignKey: 'eventId',
+});
+EventNotification.belongsTo(Event, {
+  foreignKey: 'eventId',
+});
+
 module.exports = {
   db,
   User,
@@ -118,4 +175,7 @@ module.exports = {
   Attendee,
   Reminder,
   Notification,
+  RequestNotification,
+  ReminderNotification,
+  EventNotification,
 };

--- a/database/notification.js
+++ b/database/notification.js
@@ -1,0 +1,27 @@
+const { DataTypes } = require("sequelize");
+const db = require("./db");
+
+const Notification = db.define("notifications", {
+  id: {
+    type: DataTypes.INTEGER,
+    autoIncrement: true,
+    primaryKey: true,
+  },
+  userId: {
+    type: DataTypes.INTEGER,
+    allowNull: false,
+  },
+  message: {
+    type: DataTypes.STRING,
+    allowNull: false,
+    validate: {
+      notEmpty: true,
+    },
+  },
+  type: {
+    type: DataTypes.ENUM(['request', 'reminder', 'event', 'invite']),
+    allowNull: false,
+  },
+});
+
+module.exports = Notification;

--- a/database/notification.js
+++ b/database/notification.js
@@ -11,16 +11,10 @@ const Notification = db.define("notifications", {
     type: DataTypes.INTEGER,
     allowNull: false,
   },
-  message: {
-    type: DataTypes.STRING,
+  read: {
+    type: DataTypes.BOOLEAN,
     allowNull: false,
-    validate: {
-      notEmpty: true,
-    },
-  },
-  type: {
-    type: DataTypes.ENUM(['common', 'request', 'reminder', 'event', 'invite']),
-    allowNull: false,
+    defaultValue: false,
   },
 });
 

--- a/database/notification.js
+++ b/database/notification.js
@@ -19,7 +19,7 @@ const Notification = db.define("notifications", {
     },
   },
   type: {
-    type: DataTypes.ENUM(['request', 'reminder', 'event', 'invite']),
+    type: DataTypes.ENUM(['common', 'request', 'reminder', 'event', 'invite']),
     allowNull: false,
   },
 });

--- a/database/reminder_notification.js
+++ b/database/reminder_notification.js
@@ -1,0 +1,15 @@
+const { DataTypes } = require("sequelize");
+const db = require("./db");
+
+const ReminderNotification = db.define("reminder_notification", {
+  notificationId: {
+    type: DataTypes.INTEGER,
+    primaryKey: true,
+  },
+  reminderId: {
+    type: DataTypes.INTEGER,
+    primaryKey: true,
+  }
+});
+
+module.exports = ReminderNotification;

--- a/database/request_notification.js
+++ b/database/request_notification.js
@@ -1,0 +1,15 @@
+const { DataTypes } = require("sequelize");
+const db = require("./db");
+
+const RequestNotification = db.define("request_notification", {
+  notificationId: {
+    type: DataTypes.INTEGER,
+    primaryKey: true,
+  },
+  friendshipId: {
+    type: DataTypes.INTEGER,
+    primaryKey: true,
+  }
+});
+
+module.exports = RequestNotification;

--- a/database/seed.js
+++ b/database/seed.js
@@ -7,7 +7,8 @@ const {
   CalendarItem,
   Event,
   Attendee,
-  Reminder
+  Reminder,
+  Notification,
 } = require("./index");
 
 const seed = async () => {
@@ -515,6 +516,86 @@ const seed = async () => {
     ]);
 
     console.log(`📆 Created ${calendarItems.length} calendar items with ${events.length} corresponding events`);
+
+    const notifications = await Notification.bulkCreate([
+      // Accepted Friend Requests
+      {
+        userId: 1,
+        message: `${users[1].firstName} (${users[1].username}) accepted your friend request!`,
+        type: "common",
+      },
+      {
+        userId: 1,
+        message: `${users[2].firstName} (${users[2].username}) accepted your friend request!`,
+        type: "common",
+      },
+      {
+        userId: 1,
+        message: `${users[3].firstName} (${users[3].username}) accepted your friend request!`,
+        type: "common",
+      },
+      {
+        userId: 2,
+        message: `${users[3].firstName} (${users[3].username}) accepted your friend request!`,
+        type: "common",
+      },
+      {
+        userId: 3,
+        message: `${users[1].firstName} (${users[1].username}) accepted your friend request!`,
+        type: "common",
+      },
+      {
+        userId: 4,
+        message: `${users[2].firstName} (${users[2].username}) accepted your friend request!`,
+        type: "common",
+      },
+      {
+        userId: 8,
+        message: `${users[5].firstName} (${users[5].username}) accepted your friend request!`,
+        type: "common",
+      },
+      {
+        userId: 9,
+        message: `${users[10].firstName} (${users[10].username}) accepted your friend request!`,
+        type: "common",
+      },
+      {
+        userId: 14,
+        message: `${users[12].firstName} (${users[12].username}) accepted your friend request!`,
+        type: "common",
+      },
+      {
+        userId: 14,
+        message: `${users[14].firstName} (${users[14].username}) accepted your friend request!`,
+        type: "common",
+      },
+
+      // Friend Requests Pending 1
+      {
+        userId: 6,
+        message: `${users[4].username} sent you a friend request!`,
+        type: "request",
+      },
+      {
+        userId: 12,
+        message: `${users[9].username} sent you a friend request!`,
+        type: "request",
+      },
+
+      // Friend Requests Pending 2
+      {
+        userId: 5,
+        message: `${users[6].username} sent you a friend request!`,
+        type: "request",
+      },
+      {
+        userId: 9,
+        message: `${users[10].username} sent you a friend request!`,
+        type: "request",
+      },
+    ]);
+
+    console.log(`🔔 Created ${notifications.length} notifications`);
 
     const attendees = await Attendee.bulkCreate([
       // Business Event: Weekly Team Sync (itemId: 1, owner: userId 3)

--- a/database/seed.js
+++ b/database/seed.js
@@ -9,6 +9,7 @@ const {
   Attendee,
   Reminder,
   Notification,
+  RequestNotification,
 } = require("./index");
 
 const seed = async () => {
@@ -519,80 +520,42 @@ const seed = async () => {
 
     const notifications = await Notification.bulkCreate([
       // Accepted Friend Requests
-      {
-        userId: 1,
-        message: `${users[1].firstName} (${users[1].username}) accepted your friend request!`,
-        type: "common",
-      },
-      {
-        userId: 1,
-        message: `${users[2].firstName} (${users[2].username}) accepted your friend request!`,
-        type: "common",
-      },
-      {
-        userId: 1,
-        message: `${users[3].firstName} (${users[3].username}) accepted your friend request!`,
-        type: "common",
-      },
-      {
-        userId: 2,
-        message: `${users[3].firstName} (${users[3].username}) accepted your friend request!`,
-        type: "common",
-      },
-      {
-        userId: 3,
-        message: `${users[1].firstName} (${users[1].username}) accepted your friend request!`,
-        type: "common",
-      },
-      {
-        userId: 4,
-        message: `${users[2].firstName} (${users[2].username}) accepted your friend request!`,
-        type: "common",
-      },
-      {
-        userId: 8,
-        message: `${users[5].firstName} (${users[5].username}) accepted your friend request!`,
-        type: "common",
-      },
-      {
-        userId: 9,
-        message: `${users[10].firstName} (${users[10].username}) accepted your friend request!`,
-        type: "common",
-      },
-      {
-        userId: 14,
-        message: `${users[12].firstName} (${users[12].username}) accepted your friend request!`,
-        type: "common",
-      },
-      {
-        userId: 14,
-        message: `${users[14].firstName} (${users[14].username}) accepted your friend request!`,
-        type: "common",
-      },
-
+      { userId: 1, read: true },
+      { userId: 1, read: false },
+      { userId: 1, read: true },
+      { userId: 2, read: false },
+      { userId: 3, read: false },
+      { userId: 4, read: false },
+      { userId: 8, read: false },
+      { userId: 9, read: false },
+      { userId: 14, read: false },
+      { userId: 14, read: false },
+      
       // Friend Requests Pending 1
-      {
-        userId: 6,
-        message: `${users[4].username} sent you a friend request!`,
-        type: "request",
-      },
-      {
-        userId: 12,
-        message: `${users[9].username} sent you a friend request!`,
-        type: "request",
-      },
-
+      { userId: 6, read: false },
+      { userId: 12, read: false },
+      
       // Friend Requests Pending 2
-      {
-        userId: 5,
-        message: `${users[6].username} sent you a friend request!`,
-        type: "request",
-      },
-      {
-        userId: 9,
-        message: `${users[10].username} sent you a friend request!`,
-        type: "request",
-      },
+      { userId: 5, read: false },
+      { userId: 9, read: false },
+    ]);
+
+    const request_notifications = await RequestNotification.bulkCreate([
+      { notificationId: 1, friendshipId: 1 },
+      { notificationId: 2, friendshipId: 2 },
+      { notificationId: 3, friendshipId: 3 },
+      { notificationId: 4, friendshipId: 5 },
+      { notificationId: 5, friendshipId: 4 },
+      { notificationId: 6, friendshipId: 6 },
+      { notificationId: 7, friendshipId: 9 },
+      { notificationId: 8, friendshipId: 10 },
+      { notificationId: 9, friendshipId: 13 },
+      { notificationId: 10, friendshipId: 14 },
+      
+      { notificationId: 11, friendshipId: 7 },
+      { notificationId: 12, friendshipId: 12 },
+      { notificationId: 13, friendshipId: 8 },
+      { notificationId: 14, friendshipId: 11 },
     ]);
 
     console.log(`🔔 Created ${notifications.length} notifications`);


### PR DESCRIPTION
This PR works on #21 by adding various notifications models, seed data for friend request notifications, and a route to get the authenticated user's notifications.

## Models
### [New] Notification
Base model with:
- 'id'
- 'userId' foreign key referencing the owning user
- 'read' flag for whether or not the user has marked the notification as read
### [New] Request Notification
Child model with:
- 'notification_id' foreign key referencing the parent notification
- 'friendship_id' foreign key referencing the associated friendship
### [New] Reminder Notification
Child model with:
- 'notification_id' foreign key referencing the parent notification
- 'reminder_id' foreign key referencing the associated reminder
### [New] Event Notification
Child model with:
- 'notification_id' foreign key referencing the parent notification
- 'event_id' foreign key referencing the associated event
- 'type' enum representing the type of event notification (reminder, starting, cancelled, or invite)
### [Modified] Friendship
- Changed the primary key from being [user1, user2] to the newly added 'id' attribute and made [user1, user2] a unique index instead
  - This resolves an issue of attempting to include the friendship in a subquery without knowing both users
## Seed Data
Using the existing friendships seed data, new seed data was created for friend request notifications
## Routes
A new, most likely temporary, router was created for notifications specifically with one route that gets the users notifications, formatting them based on their notification type before sending it back to the client