### PR TITLE
Bug Fixes for Presentation

### DIFF
--- a/api/users.js
+++ b/api/users.js
@@ -143,6 +143,9 @@ router.get("/me/friends", authenticateJWT, async (req, res) => {
       status: friendship.status,
       user:
         friendship.user1 === userId ? friendship.secondary : friendship.primary,
+      pendingUser:
+        (friendship.status === 'pending1' && friendship.user1 === userId) ||
+        (friendship.status === 'pending2' && friendship.user2 === userId)
     }));
 
     // Send back status of 200 if everything goes through and send the friends


### PR DESCRIPTION
This PR adds the pendingUser property to the objects in the response array in the "/api/profiles/me/friends" route.  It denotes whether or not the given friendship is pending the authenticated user's response. Used in the profile page on the front end.